### PR TITLE
backgroundColor / version code / error text

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pull requests are always welcomed.
 In the `dependencies:` section of your `pubspec.yaml`, add the following line:
 
 ```yaml
-  pin_code_view: 0.1
+  pin_code_view: 0.1.1
 ```
 
 ## Usage

--- a/lib/code_view.dart
+++ b/lib/code_view.dart
@@ -30,9 +30,7 @@ class CodeViewState extends State<CodeView> {
           margin: EdgeInsets.all(5.0),
           decoration: BoxDecoration(
             color: Colors.black12,
-            borderRadius: BorderRadius.all(
-              Radius.circular(10.0),
-            ),
+            border: Border(bottom: BorderSide(color: Colors.white)),
           ),
           padding: EdgeInsets.fromLTRB(15.0, 10.0, 15.0, 10.0),
           child: Text(

--- a/lib/pin_code_view.dart
+++ b/lib/pin_code_view.dart
@@ -55,7 +55,7 @@ class PinCodeState extends State<PinCode> {
                 ),
                 Text(
                   '${widget.error}',
-                  style: this.errorTextStyle,
+                  style: this.widget.errorTextStyle,
                 ),
                 Expanded(child: Container()),
               ],

--- a/lib/pin_code_view.dart
+++ b/lib/pin_code_view.dart
@@ -22,7 +22,7 @@ class PinCode extends StatefulWidget {
     this.keyTextStyle = const TextStyle(color: Colors.white, fontSize: 25.0),
     this.codeTextStyle = const TextStyle(
         color: Colors.white, fontSize: 25.0, fontWeight: FontWeight.bold),
-    this.backgroundColor,
+    this.backgroundColor = Theme.of(context).primaryColor,
   });
 
   PinCodeState createState() => PinCodeState();

--- a/lib/pin_code_view.dart
+++ b/lib/pin_code_view.dart
@@ -7,7 +7,7 @@ class PinCode extends StatefulWidget {
   final String error;
   final Function onCodeEntered;
   final int codeLength;
-  final TextStyle keyTextStyle, codeTextStyle;
+  final TextStyle keyTextStyle, codeTextStyle, errorTextStyle;
   final bool obscurePin;
   final Color backgroundColor;
 
@@ -18,6 +18,7 @@ class PinCode extends StatefulWidget {
     this.codeLength = 6,
     this.obscurePin = false,
     this.onCodeEntered,
+    this.errorTextStyle = const TextStyle(color: Colors.red, fontSize: 15),
     this.keyTextStyle = const TextStyle(color: Colors.white, fontSize: 25.0),
     this.codeTextStyle = const TextStyle(
         color: Colors.white, fontSize: 25.0, fontWeight: FontWeight.bold),
@@ -53,8 +54,8 @@ class PinCodeState extends State<PinCode> {
                   length: widget.codeLength,
                 ),
                 Text(
-                  "${widget.error}",
-                  style: TextStyle(color: Colors.red, fontSize: 15),
+                  '${widget.error}',
+                  style: this.errorTextStyle,
                 ),
                 Expanded(child: Container()),
               ],

--- a/lib/pin_code_view.dart
+++ b/lib/pin_code_view.dart
@@ -8,6 +8,7 @@ class PinCode extends StatefulWidget {
   final int codeLength;
   final TextStyle keyTextStyle, codeTextStyle;
   final bool obscurePin;
+  final Color backgroundColor;
 
   PinCode({
     this.title,
@@ -18,6 +19,7 @@ class PinCode extends StatefulWidget {
     this.keyTextStyle = const TextStyle(color: Colors.white, fontSize: 25.0),
     this.codeTextStyle = const TextStyle(
         color: Colors.white, fontSize: 25.0, fontWeight: FontWeight.bold),
+    this.backgroundColor,
   });
 
   PinCodeState createState() => PinCodeState();
@@ -29,7 +31,7 @@ class PinCodeState extends State<PinCode> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Theme.of(context).primaryColor,
+      color: widget.backgroundColor,
       child: Column(children: <Widget>[
         Expanded(
           child: Padding(

--- a/lib/pin_code_view.dart
+++ b/lib/pin_code_view.dart
@@ -4,6 +4,7 @@ import './code_view.dart';
 
 class PinCode extends StatefulWidget {
   final Text title, subTitle;
+  final String error;
   final Function onCodeEntered;
   final int codeLength;
   final TextStyle keyTextStyle, codeTextStyle;
@@ -12,6 +13,7 @@ class PinCode extends StatefulWidget {
 
   PinCode({
     this.title,
+    this.error = '',
     this.subTitle,
     this.codeLength = 6,
     this.obscurePin = false,
@@ -49,6 +51,10 @@ class PinCodeState extends State<PinCode> {
                   code: smsCode,
                   obscurePin: widget.obscurePin,
                   length: widget.codeLength,
+                ),
+                Text(
+                  "${widget.error}",
+                  style: TextStyle(color: Colors.red, fontSize: 15),
                 ),
                 Expanded(child: Container()),
               ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pin_code_view
 description: A flutter plugin to show beautiful pin code view. A on screen keyboard is placed at the bottom of the screen and a code view with blocks are added on the top of the screen.
-version: 0.1.0
+version: 0.1.1
 author: Aawaz Gyawali <awazgyawali@gmail.com>
 homepage: https://github.com/awazgyawali/pin_code_view
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pin_code_view
 description: A flutter plugin to show beautiful pin code view. A on screen keyboard is placed at the bottom of the screen and a code view with blocks are added on the top of the screen.
-version: 0.1
+version: 0.1.0
 author: Aawaz Gyawali <awazgyawali@gmail.com>
 homepage: https://github.com/awazgyawali/pin_code_view
 


### PR DESCRIPTION
1- miss typo in version code ,, makes pub get to fail ,,
 (version must be x.y.z not x.y ,, so it must be 0.1.0 instead of 0.1 only)

lib/code_view.dart
=> better ui for pin boxes

lib/pin_code_view.dart
=> added backgroundColor ,, so you don't force them to use theme.of context
and it's optional so if they didn't give one we will use theme of context

=> added error text ,, if pin fails! ,, seems logic to show error when it's wrong
and it's style is given too in contractor as optional parameter